### PR TITLE
fix import issue of AGENT_LLM_MAP

### DIFF
--- a/src/podcast/graph/script_writer_node.py
+++ b/src/podcast/graph/script_writer_node.py
@@ -5,7 +5,7 @@ import logging
 
 from langchain.schema import HumanMessage, SystemMessage
 
-from src.config.agents import AGENT_LLM_MAP
+from src.config.agents import AgentConfiguration
 from src.llms.llm import get_llm_by_type
 from src.prompts.template import get_prompt_template
 
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 def script_writer_node(state: PodcastState):
     logger.info("Generating script for podcast...")
     model = get_llm_by_type(
-        AGENT_LLM_MAP["podcast_script_writer"]
+        AgentConfiguration.AGENT_LLM_MAP["podcast_script_writer"]
     ).with_structured_output(Script, method="json_mode")
     script = model.invoke(
         [

--- a/src/ppt/graph/ppt_composer_node.py
+++ b/src/ppt/graph/ppt_composer_node.py
@@ -7,7 +7,7 @@ import uuid
 
 from langchain.schema import HumanMessage, SystemMessage
 
-from src.config.agents import AGENT_LLM_MAP
+from src.config.agents import AgentConfiguration
 from src.llms.llm import get_llm_by_type
 from src.prompts.template import get_prompt_template
 
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 
 def ppt_composer_node(state: PPTState):
     logger.info("Generating ppt content...")
-    model = get_llm_by_type(AGENT_LLM_MAP["ppt_composer"])
+    model = get_llm_by_type(AgentConfiguration.AGENT_LLM_MAP["ppt_composer"])
     ppt_content = model.invoke(
         [
             SystemMessage(content=get_prompt_template("ppt/ppt_composer")),

--- a/src/prose/graph/prose_continue_node.py
+++ b/src/prose/graph/prose_continue_node.py
@@ -5,7 +5,7 @@ import logging
 
 from langchain.schema import HumanMessage, SystemMessage
 
-from src.config.agents import AGENT_LLM_MAP
+from src.config.agents import AgentConfiguration
 from src.llms.llm import get_llm_by_type
 from src.prompts.template import get_prompt_template
 from src.prose.graph.state import ProseState
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 def prose_continue_node(state: ProseState):
     logger.info("Generating prose continue content...")
-    model = get_llm_by_type(AGENT_LLM_MAP["prose_writer"])
+    model = get_llm_by_type(AgentConfiguration.AGENT_LLM_MAP["prose_writer"])
     prose_content = model.invoke(
         [
             SystemMessage(content=get_prompt_template("prose/prose_continue")),

--- a/src/prose/graph/prose_fix_node.py
+++ b/src/prose/graph/prose_fix_node.py
@@ -5,7 +5,7 @@ import logging
 
 from langchain.schema import HumanMessage, SystemMessage
 
-from src.config.agents import AGENT_LLM_MAP
+from src.config.agents import AgentConfiguration
 from src.llms.llm import get_llm_by_type
 from src.prompts.template import get_prompt_template
 from src.prose.graph.state import ProseState
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 def prose_fix_node(state: ProseState):
     logger.info("Generating prose fix content...")
-    model = get_llm_by_type(AGENT_LLM_MAP["prose_writer"])
+    model = get_llm_by_type(AgentConfiguration.AGENT_LLM_MAP["prose_writer"])
     prose_content = model.invoke(
         [
             SystemMessage(content=get_prompt_template("prose/prose_fix")),

--- a/src/prose/graph/prose_improve_node.py
+++ b/src/prose/graph/prose_improve_node.py
@@ -5,7 +5,7 @@ import logging
 
 from langchain.schema import HumanMessage, SystemMessage
 
-from src.config.agents import AGENT_LLM_MAP
+from src.config.agents import AgentConfiguration
 from src.llms.llm import get_llm_by_type
 from src.prose.graph.state import ProseState
 from src.prompts.template import get_prompt_template
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 def prose_improve_node(state: ProseState):
     logger.info("Generating prose improve content...")
-    model = get_llm_by_type(AGENT_LLM_MAP["prose_writer"])
+    model = get_llm_by_type(AgentConfiguration.AGENT_LLM_MAP["prose_writer"])
     prose_content = model.invoke(
         [
             SystemMessage(content=get_prompt_template("prose/prose_improver")),

--- a/src/prose/graph/prose_longer_node.py
+++ b/src/prose/graph/prose_longer_node.py
@@ -5,7 +5,7 @@ import logging
 
 from langchain.schema import HumanMessage, SystemMessage
 
-from src.config.agents import AGENT_LLM_MAP
+from src.config.agents import AgentConfiguration
 from src.llms.llm import get_llm_by_type
 from src.prompts.template import get_prompt_template
 from src.prose.graph.state import ProseState
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 def prose_longer_node(state: ProseState):
     logger.info("Generating prose longer content...")
-    model = get_llm_by_type(AGENT_LLM_MAP["prose_writer"])
+    model = get_llm_by_type(AgentConfiguration.AGENT_LLM_MAP["prose_writer"])
     prose_content = model.invoke(
         [
             SystemMessage(content=get_prompt_template("prose/prose_longer")),

--- a/src/prose/graph/prose_shorter_node.py
+++ b/src/prose/graph/prose_shorter_node.py
@@ -5,7 +5,7 @@ import logging
 
 from langchain.schema import HumanMessage, SystemMessage
 
-from src.config.agents import AGENT_LLM_MAP
+from src.config.agents import AgentConfiguration
 from src.llms.llm import get_llm_by_type
 from src.prompts.template import get_prompt_template
 from src.prose.graph.state import ProseState
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 def prose_shorter_node(state: ProseState):
     logger.info("Generating prose shorter content...")
-    model = get_llm_by_type(AGENT_LLM_MAP["prose_writer"])
+    model = get_llm_by_type(AgentConfiguration.AGENT_LLM_MAP["prose_writer"])
     prose_content = model.invoke(
         [
             SystemMessage(content=get_prompt_template("prose/prose_shorter")),

--- a/src/prose/graph/prose_zap_node.py
+++ b/src/prose/graph/prose_zap_node.py
@@ -5,7 +5,7 @@ import logging
 
 from langchain.schema import HumanMessage, SystemMessage
 
-from src.config.agents import AGENT_LLM_MAP
+from src.config.agents import AgentConfiguration
 from src.llms.llm import get_llm_by_type
 from src.prompts.template import get_prompt_template
 from src.prose.graph.state import ProseState
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 def prose_zap_node(state: ProseState):
     logger.info("Generating prose zap content...")
-    model = get_llm_by_type(AGENT_LLM_MAP["prose_writer"])
+    model = get_llm_by_type(AgentConfiguration.AGENT_LLM_MAP["prose_writer"])
     prose_content = model.invoke(
         [
             SystemMessage(content=get_prompt_template("prose/prose_zap")),


### PR DESCRIPTION
项目中的 dev/main 分支中， src/config/agents.py 文件下有个类定义是
```
class AgentConfiguration:
    """全局配置类"""
    
    # Agent-LLM映射
    AGENT_LLM_MAP: Dict[str, LLMType] = {
......
```

但是在其他文件中（如：src/podcast/graph/script_writer_node.py ),是使用下列语句来导入的
```
from src.config.agents import AGENT_LLM_MAP
```
导致项目运行直接报错了。为什么不是使用
```
from src.config.agents import AgentConfiguration
```
后续使用 `AgentConfiguration.AGENT_LLM_MAP` ?